### PR TITLE
drivers: dma: max32: skip channel isr callback if no interrupt bit is set

### DIFF
--- a/drivers/dma/dma_max32.c
+++ b/drivers/dma/dma_max32.c
@@ -258,6 +258,11 @@ static void max32_dma_isr(const struct device *dev)
 			continue;
 		}
 
+		/* check if only enabled bit is set (interrupt is not there) and skip it */
+		if (flags == ADI_MAX32_DMA_STATUS_ST) {
+			continue;
+		}
+
 		/* Check for error interrupts */
 		if (flags & (ADI_MAX32_DMA_STATUS_BUS_ERR | ADI_MAX32_DMA_STATUS_TO_IF)) {
 			status = -EIO;


### PR DESCRIPTION
Description:

we iterate over all the channels, and if more than one channel is active at a time. interrupt on any one of active channel was triggering callback for other active channel, because flags value is 1 (enabled). this is commit handle this behavior and only trigger callback if bits other than status is set